### PR TITLE
Work with Outlook 15.38

### DIFF
--- a/Send_to_OmniFocus.applescript
+++ b/Send_to_OmniFocus.applescript
@@ -229,7 +229,7 @@ on item_Process(selectedItems)
 		else
 			--FULL ITEM EXPORT
 			repeat with selectedItem in selectedItems
-				set theProps to (properties of selectedItem)
+				set theProps to selectedItem
 				try
 					set theAttachments to attachments of selectedItem
 					set raw_Attendees to attendees of selectedItem


### PR DESCRIPTION
Without this fix, when I run the workflow, I get nothing in the Alfred workflow debug pane, but in Console.app, I see:

```
default 09:42:24.815664 -0700   Microsoft Outlook       An exception was thrown during execution of an NSScriptCommand...
default 09:42:24.815747 -0700   Microsoft Outlook       [<ECMessage 0x600002a26040> valueForUndefinedKey:]: this class is not key value coding-compliant for the key edited.
```

So this looks like perhaps a bug in Outlook that it is not key value coding-compliant, but this simple change seems to make it work.